### PR TITLE
#120 error map

### DIFF
--- a/script-wrapper/src/integrationTest/groovy/org/cedar/psi/wrapper/WrapperIntegrationSpec.groovy
+++ b/script-wrapper/src/integrationTest/groovy/org/cedar/psi/wrapper/WrapperIntegrationSpec.groovy
@@ -129,7 +129,7 @@ class WrapperIntegrationSpec extends Specification{
     output.key() == message.trackingId
 
     and:
-    output.value().startsWith('ERROR')
+    new JsonSlurper().parseText(output.value()).containsKey('error')
   }
 
 }

--- a/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/stream/ScriptWrapperFunctions.groovy
+++ b/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/stream/ScriptWrapperFunctions.groovy
@@ -28,7 +28,7 @@ class ScriptWrapperFunctions {
         log.error "Process exited with non-zero exit code"
         log.error "Process stdout: ${stdout}"
         log.error "Process stderr: ${stderr}"
-        return JsonOutput.toJson([error: stderr])
+        return JsonOutput.toJson([error: "$stderr"])
       } else {
         log.info "Publishing : $stdout"
         return stdout.toString()
@@ -36,7 +36,7 @@ class ScriptWrapperFunctions {
     }
     catch (Exception e) {
       log.error("Caught exception $e: ${e.message}")
-      return JsonOutput.toJson([error: e.message])
+      return JsonOutput.toJson([error: "${e.message}"])
     }
   }
 
@@ -65,7 +65,7 @@ class ScriptWrapperFunctions {
       }
 
     } catch (Exception e) {
-      return JsonOutput.toJson([error:e.message])
+      return JsonOutput.toJson([error:"${e.message}"])
     }
     // is neither xml nor json --> is error
     return JsonOutput.toJson([error: 'Output is neither xml nor json: ' + message])

--- a/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/stream/ScriptWrapperFunctions.groovy
+++ b/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/stream/ScriptWrapperFunctions.groovy
@@ -28,7 +28,7 @@ class ScriptWrapperFunctions {
         log.error "Process exited with non-zero exit code"
         log.error "Process stdout: ${stdout}"
         log.error "Process stderr: ${stderr}"
-        return 'ERROR: ' + stderr
+        return JsonOutput.toJson([error: stderr])
       } else {
         log.info "Publishing : $stdout"
         return stdout.toString()
@@ -36,7 +36,7 @@ class ScriptWrapperFunctions {
     }
     catch (Exception e) {
       log.error("Caught exception $e: ${e.message}")
-      return 'ERROR: ' + e.message
+      return JsonOutput.toJson([error: e.message])
     }
   }
 
@@ -65,9 +65,9 @@ class ScriptWrapperFunctions {
       }
 
     } catch (Exception e) {
-      return 'ERROR: ' + e.message
+      return JsonOutput.toJson([error:e.message])
     }
     // is neither xml nor json --> is error
-    return 'ERROR: Output is neither xml nor json: ' + message
+    return JsonOutput.toJson([error: 'Output is neither xml nor json: ' + message])
   }
 }

--- a/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/util/TopologyUtil.groovy
+++ b/script-wrapper/src/main/groovy/org/cedar/psi/wrapper/util/TopologyUtil.groovy
@@ -1,5 +1,6 @@
 package org.cedar.psi.wrapper.util
 
+import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.Topology
@@ -18,16 +19,19 @@ class TopologyUtil {
     def errorOut = topologyConfig.topics.errorout as String
 
     Topology topology = builder.build()
+    //stream incoming messages
     KStream inputStream = builder.stream(topologyConfig.topics.input as String)
+    //pass them through the script
     KStream scriptOutputStream = inputStream.mapValues({ msg -> ScriptWrapperFunctions.scriptCaller(msg, command, timeout) })
-
     //split script output into 2 streams, one for good and one for bad
     KStream[] goodAndBadStreams = scriptOutputStream.branch(isValid, isNotValid)
     KStream goodStream = goodAndBadStreams[0]
     KStream badStream = goodAndBadStreams.size() > 1 ? goodAndBadStreams[1] : null
 
-    //send error to errorout topic and good msgs through parser
+    //send the bad stream off to the error topic
     if(badStream){badStream.to(errorOut)}
+
+    //pass the good stream through the parser
     KStream parsedStream = goodStream.mapValues({ msg -> ScriptWrapperFunctions.parseOutput(msg as String) })
 
     //split the parsed stream into valid and invalid streams
@@ -35,15 +39,17 @@ class TopologyUtil {
     KStream goodParsedStream = parsedGoodAndBadStreams[0]
     KStream badParsedStream = parsedGoodAndBadStreams.size() > 1 ? parsedGoodAndBadStreams[1] : null
 
-    //send the error msgs to the error topic, otherwise
+    //send the error msgs to the error topic
     if(badParsedStream){badParsedStream.to(errorOut)}
+
+    //send the good messages into the output topic
     goodParsedStream.to(outputTopic)
 
     return topology
   }
 
-  // filter incoming stream
-  static Predicate isValid = { k, v -> !v.toString().startsWith('ERROR') }
-  static Predicate isNotValid = { k, v -> v.toString().startsWith('ERROR') }
+  static Predicate isValid = {k, v -> !new JsonSlurper().parseText(v as String).containsKey('error') }
+  static Predicate isNotValid = {k, v -> new JsonSlurper().parseText(v as String).containsKey('error') }
 
 }
+

--- a/script-wrapper/src/test/groovy/org/cedar/psi/wrapper/ScriptWrapperFunctionsSpec.groovy
+++ b/script-wrapper/src/test/groovy/org/cedar/psi/wrapper/ScriptWrapperFunctionsSpec.groovy
@@ -20,7 +20,7 @@ class ScriptWrapperFunctionsSpec extends Specification {
 
   void "Script wrapper exit with value 0: command not provided"() {
     String command = " "
-    def expected = 'ERROR: ' + 0
+    def expected = JsonOutput.toJson([ error : '0' ])
 
     expect:
     ScriptWrapperFunctions.scriptCaller(msg, command, command_timeout) == expected
@@ -28,7 +28,7 @@ class ScriptWrapperFunctionsSpec extends Specification {
 
   void "Script wrapper exit with value non-zero value: command Cannot run program"() {
     String command = "py wrong command"
-    def expected = 'ERROR: Cannot run program "py": error=2, No such file or directory'
+    def expected = JsonOutput.toJson([error: 'Cannot run program "py": error=2, No such file or directory'])
 
     expect:
     ScriptWrapperFunctions.scriptCaller(msg, command, command_timeout) == expected
@@ -82,7 +82,7 @@ class ScriptWrapperFunctionsSpec extends Specification {
 
   def 'returns an error if neither xml nor json output is provided'() {
     expect:
-    ScriptWrapperFunctions.parseOutput('not a good response').startsWith('ERROR')
+    new JsonSlurper().parseText(ScriptWrapperFunctions.parseOutput('not a good response')).containsKey('error')
   }
 
 }


### PR DESCRIPTION
closes #120 

Instead a string starting with 'ERROR:' on the error topic, now we should have a string of valid json 

e.g. {"error":"your script is bad and you should feel bad"}